### PR TITLE
SMOODEV-662: Sync SmooAI.File + SmooAI.File.S3 NuGet versions to npm + polish NuGet READMEs

### DIFF
--- a/.changeset/smoodev-662-dotnet-version-sync.md
+++ b/.changeset/smoodev-662-dotnet-version-sync.md
@@ -1,0 +1,5 @@
+---
+'@smooai/file': patch
+---
+
+SMOODEV-662: Sync SmooAI.File + SmooAI.File.S3 NuGet versions to package.json + polish NuGet READMEs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,17 +134,15 @@ jobs:
             - name: Pack and publish SmooAI.File + SmooAI.File.S3 to NuGet
               if: steps.changesets.outputs.published == 'true'
               run: |
+                  # Version is sourced from csproj <Version>, which sync-versions.mjs
+                  # kept in lockstep with package.json before changeset publish ran.
                   VERSION=$(node -p "require('./package.json').version")
-                  echo "Packing .NET version ${VERSION}"
+                  echo "Packing .NET version ${VERSION} (from csproj)"
                   dotnet pack dotnet/src/SmooAI.File/SmooAI.File.csproj \
                       --configuration Release \
-                      -p:Version=${VERSION} \
-                      -p:PackageVersion=${VERSION} \
                       -o dotnet/artifacts
                   dotnet pack dotnet/src/SmooAI.File.S3/SmooAI.File.S3.csproj \
                       --configuration Release \
-                      -p:Version=${VERSION} \
-                      -p:PackageVersion=${VERSION} \
                       -o dotnet/artifacts
 
                   for pkg in dotnet/artifacts/*.nupkg; do

--- a/dotnet/src/SmooAI.File.S3/README.md
+++ b/dotnet/src/SmooAI.File.S3/README.md
@@ -1,8 +1,8 @@
 # SmooAI.File.S3
 
-S3 helpers for [`SmooAI.File`](https://www.nuget.org/packages/SmooAI.File).
-Kept in a separate package so apps that only need MIME detection and
-validation don't pull in the AWS SDK.
+**S3 upload, download, and presigned-URL helpers for [`SmooAI.File`](https://www.nuget.org/packages/SmooAI.File) — typed, cancellable, and still magic-byte-safe.**
+
+Companion package to [`SmooAI.File`](https://www.nuget.org/packages/SmooAI.File). Split on purpose — apps that only need local MIME detection and validation don't pay the `AWSSDK.S3` install cost.
 
 ## Install
 
@@ -10,7 +10,9 @@ validation don't pull in the AWS SDK.
 dotnet add package SmooAI.File.S3
 ```
 
-## Usage
+(Also brings in `SmooAI.File`.)
+
+## Quick start
 
 ```csharp
 using Amazon.S3;
@@ -19,23 +21,50 @@ using SmooAI.File.S3;
 
 var s3 = new AmazonS3Client();
 
-// Load an S3 object as a SmooFile (magic-byte MIME detection still applies).
+// Load an S3 object as a SmooFile — magic-byte MIME detection still applies
 var file = await S3SmooFile.CreateFromS3Async(s3, "my-bucket", "uploads/foo.bin");
+file.Validate(allowedMimes: new[] { "image/png", "image/jpeg", "application/pdf" });
 
-// Generate a presigned URL so a client can PUT directly to S3.
+// Upload a SmooFile to S3
+await file.UploadToS3Async(s3, "my-bucket", "destination/key");
+
+// Save an S3 object directly to a local path
+await S3SmooFile.SaveFromS3ToFileAsync(s3, "my-bucket", "uploads/foo.bin", "/tmp/foo.bin");
+```
+
+## Presigned uploads
+
+Let the browser `PUT` directly to S3 — your API never touches the bytes:
+
+```csharp
 var uploadUrl = await S3SmooFile.CreatePresignedUploadUrlAsync(s3, new()
 {
-    Bucket = "my-bucket",
-    Key = $"avatars/{userId}.png",
+    Bucket      = "my-bucket",
+    Key         = $"avatars/{userId}.png",
     ContentType = "image/png",
-    ExpiresIn = TimeSpan.FromMinutes(10),
-    MaxSize = 2 * 1024 * 1024,
+    ExpiresIn   = TimeSpan.FromMinutes(10),
+    MaxSize     = 2 * 1024 * 1024,   // enforced by signed policy
 });
 
-// Upload a SmooFile to S3.
-await file.UploadToS3Async(s3, "my-bucket", "destination/key");
+// Return uploadUrl to the client; they PUT the file straight to S3.
 ```
+
+After the client uploads, pull it back through `SmooFile` to magic-byte-verify the content before using it:
+
+```csharp
+var uploaded = await S3SmooFile.CreateFromS3Async(s3, "my-bucket", $"avatars/{userId}.png");
+uploaded.Validate(
+    maxSize:          2 * 1024 * 1024,
+    allowedMimes:     new[] { "image/png", "image/jpeg" },
+    expectedMimeType: "image/png");
+```
+
+## Related
+
+- [`SmooAI.File`](https://www.nuget.org/packages/SmooAI.File) — base package, required
+- [`@smooai/file`](https://www.npmjs.com/package/@smooai/file) — TypeScript / Node
+- [`smooai-file`](https://crates.io/crates/smooai-file) — Rust
 
 ## License
 
-MIT
+MIT — © SmooAI

--- a/dotnet/src/SmooAI.File.S3/SmooAI.File.S3.csproj
+++ b/dotnet/src/SmooAI.File.S3/SmooAI.File.S3.csproj
@@ -4,6 +4,7 @@
     <PackageId>SmooAI.File.S3</PackageId>
     <RootNamespace>SmooAI.File.S3</RootNamespace>
     <AssemblyName>SmooAI.File.S3</AssemblyName>
+    <Version>2.2.0</Version>
     <Description>S3 helpers for SmooAI.File — createPresignedUploadUrl, createFromS3, uploadToS3, saveToS3.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/dotnet/src/SmooAI.File/README.md
+++ b/dotnet/src/SmooAI.File/README.md
@@ -1,8 +1,8 @@
 # SmooAI.File
 
-.NET port of [`@smooai/file`](https://github.com/SmooAI/file). Provides a
-`SmooFile` wrapper that uses [Mime-Detective](https://github.com/MediatedCommunications/Mime-Detective)
-for magic-byte MIME detection and typed validation errors.
+**Magic-byte MIME detection, typed validation errors, and stream helpers for .NET — because `Content-Type` headers lie.**
+
+.NET port of [`@smooai/file`](https://github.com/SmooAI/file). Built on [Mime-Detective](https://github.com/MediatedCommunications/Mime-Detective) for real MIME sniffing (not extension guessing). Wire-compatible semantics with the TypeScript, Python, Go, and Rust ports.
 
 ## Install
 
@@ -10,57 +10,102 @@ for magic-byte MIME detection and typed validation errors.
 dotnet add package SmooAI.File
 ```
 
-For S3 upload/download helpers, also add:
+Need S3 upload/download helpers? Add the companion package:
 
 ```bash
 dotnet add package SmooAI.File.S3
 ```
 
-The S3 helpers are intentionally split so apps that don't need AWS don't pull in `AWSSDK.S3`.
+Split on purpose — apps that only need MIME detection and validation don't pull in `AWSSDK.S3`.
 
-## Usage
+## Quick start
 
 ```csharp
 using SmooAI.File;
 
-// From a stream (e.g. multipart upload)
+// From an ASP.NET Core upload
 await using var upload = formFile.OpenReadStream();
 var file = await SmooFile.CreateFromStreamAsync(upload, options =>
 {
-    options.Name = formFile.FileName;
-    options.MaxSizeBytes = 10_000_000;
+    options.Name             = formFile.FileName;
+    options.ExpectedMimeType = formFile.ContentType;   // client-claimed
+    options.MaxSizeBytes     = 10_000_000;
     options.AllowedMimeTypes = new[] { "image/png", "image/jpeg", "application/pdf" };
 });
 
-file.Validate(
-    maxSize: 10_000_000,
-    allowedMimes: new[] { "image/png", "image/jpeg", "application/pdf" },
-    expectedMimeType: formFile.ContentType);
+// One call — throws typed exceptions on violation
+file.Validate();
 
-// Read as base64 for an email attachment or data URL
+// Detected MIME reflects what the bytes *actually* are
+Console.WriteLine(file.Detected.MimeType);   // e.g. "image/png"
+
+// Emit as base64 for an email attachment / data URL
 var b64 = await file.ToBase64Async();
 
-// Or save it to disk
+// Or persist
 await file.SaveToFileAsync("/tmp/upload.bin");
 ```
 
 ## Why magic-byte detection
 
-File extensions and `Content-Type` headers lie. `file.docx` may actually be a
-ZIP, a `.php` can be uploaded as `image/png`. `SmooFile.Detected.MimeType`
-always reflects what the file actually contains, and `Validate(expectedMimeType:
-…)` throws a typed `FileContentMismatchException` when claims disagree.
+File extensions and `Content-Type` headers are untrusted client input. `file.docx` may actually be a ZIP. A `.php` can masquerade as `image/png`. `SmooFile.Detected.MimeType` reflects the real bytes — and `Validate(expectedMimeType: …)` throws `FileContentMismatchException` the moment claim disagrees with content.
+
+```csharp
+// Client uploads a PHP shell renamed to avatar.png
+var file = await SmooFile.CreateFromStreamAsync(stream, opts =>
+{
+    opts.Name             = "avatar.png";
+    opts.ExpectedMimeType = "image/png";
+});
+
+file.Validate(allowedMimes: new[] { "image/png", "image/jpeg" });
+// -> throws FileContentMismatchException
+//    Detected: "text/x-php", Expected: "image/png"
+```
 
 ## Validation errors
 
-All validation errors derive from `FileValidationException`, so one `catch`
-block maps to a `400` response:
+One base class — one `catch` block on the controller. All typed, all actionable, all 400-worthy:
 
-- `FileSizeException` — file exceeds `maxSize`
-- `FileMimeException` — MIME not in `allowedMimes`
-- `FileContentMismatchException` — client-claimed MIME disagrees with
-  magic-byte-detected MIME
+| Exception | When |
+|---|---|
+| `FileSizeException` | File exceeds `maxSize` |
+| `FileMimeException` | MIME not in `allowedMimes` |
+| `FileContentMismatchException` | Client-claimed MIME disagrees with magic-byte-detected MIME |
+| `FileValidationException` | Base class — catch this to handle all validation failures |
+
+```csharp
+try
+{
+    file.Validate();
+}
+catch (FileValidationException ex)
+{
+    return Results.Problem(ex.Message, statusCode: 400);
+}
+```
+
+## Creating from other sources
+
+```csharp
+// From a byte buffer
+var file = await SmooFile.CreateFromBytesAsync(bytes, opts => { opts.Name = "thing.bin"; });
+
+// From a file path
+var file = await SmooFile.CreateFromPathAsync("/tmp/upload.bin");
+
+// From a URL (streams, doesn't buffer the full body into memory)
+var file = await SmooFile.CreateFromUrlAsync("https://example.com/report.pdf");
+```
+
+## Related
+
+- [`SmooAI.File.S3`](https://www.nuget.org/packages/SmooAI.File.S3) — presigned uploads + S3 helpers (split package)
+- [`@smooai/file`](https://www.npmjs.com/package/@smooai/file) — TypeScript / Node
+- [`smooai-file`](https://crates.io/crates/smooai-file) — Rust
+- [`smooai-file`](https://pypi.org/project/smooai-file/) — Python
+- [`github.com/SmooAI/file/go/file`](https://github.com/SmooAI/file/tree/main/go/file) — Go
 
 ## License
 
-MIT
+MIT — © SmooAI

--- a/dotnet/src/SmooAI.File/SmooAI.File.csproj
+++ b/dotnet/src/SmooAI.File/SmooAI.File.csproj
@@ -4,6 +4,7 @@
     <PackageId>SmooAI.File</PackageId>
     <RootNamespace>SmooAI.File</RootNamespace>
     <AssemblyName>SmooAI.File</AssemblyName>
+    <Version>2.2.0</Version>
     <Description>File utilities with magic-byte MIME detection (via Mime-Detective) and typed validation errors. Use SmooAI.File.S3 for S3 upload/download helpers.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -32,6 +32,16 @@ const files = [
         pattern: /const Version = ".*"/,
         replacement: `const Version = "${version}"`,
     },
+    {
+        path: join(rootDir, 'dotnet', 'src', 'SmooAI.File', 'SmooAI.File.csproj'),
+        pattern: /<Version>.*<\/Version>/,
+        replacement: `<Version>${version}</Version>`,
+    },
+    {
+        path: join(rootDir, 'dotnet', 'src', 'SmooAI.File.S3', 'SmooAI.File.S3.csproj'),
+        pattern: /<Version>.*<\/Version>/,
+        replacement: `<Version>${version}</Version>`,
+    },
 ];
 
 for (const file of files) {


### PR DESCRIPTION
## Summary
- Extend `scripts/sync-versions.mjs` to set `<Version>` in both `dotnet/src/SmooAI.File/SmooAI.File.csproj` and `dotnet/src/SmooAI.File.S3/SmooAI.File.S3.csproj` from `package.json`.
- Add `<Version>` properties to both csprojs (previously the release workflow injected via `-p:Version` each run); sync script now owns them and keeps them in lockstep with npm.
- Rewrite both NuGet READMEs (`SmooAI.File`, `SmooAI.File.S3`) with hero blurbs, quickstart snippets, magic-byte attack example, typed exception table, presigned-upload flow, and sibling-language package links.
- Drop `-p:Version` / `-p:PackageVersion` overrides in `release.yml` — `dotnet pack` now sources Version from the sync'd csproj directly.
- Version bumped 0.1.0 → 2.2.0 on both packages (matches npm via sync script).

## Test plan
- [x] `node scripts/sync-versions.mjs` updates both csproj `<Version>` elements to match `package.json`.
- [x] `<None Include="README.md" Pack="true" PackagePath="\" />` already present on both csprojs; `<PackageReadmeFile>README.md</PackageReadmeFile>` already present.
- [ ] After merge, Changesets opens the version PR; release workflow packs and pushes SmooAI.File + SmooAI.File.S3 2.2.0 to nuget.org via `NUGET_API_KEY`.

Jira: [SMOODEV-662](https://smooai.atlassian.net/browse/SMOODEV-662)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SMOODEV-662]: https://smooai.atlassian.net/browse/SMOODEV-662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ