### PR TITLE
SMOODEV-664: Rewrite READMEs — value-framed (trust the bytes, not the extension)

### DIFF
--- a/.changeset/smoodev-664-readme-value-frame.md
+++ b/.changeset/smoodev-664-readme-value-frame.md
@@ -1,0 +1,5 @@
+---
+'@smooai/file': patch
+---
+
+SMOODEV-664: Rewrite READMEs to value-frame the package — lead with "file operations that don't lie": magic-byte MIME detection vs spoofed extensions, size + content validation, presigned S3 uploads. Drop the "powerful file handling library" stock lead and reorder "Key Features" so validation comes first. Republishes @smooai/file on npm plus SmooAI.File and SmooAI.File.S3 on NuGet with the new READMEs.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This library is part of a small family of open-source packages we maintain to ke
 
 ## About @smooai/file
 
-A powerful file handling library for Node.js that provides a unified interface for working with files from local filesystem, S3, URLs, and more. Built with streaming in mind, it handles file bytes lazily where possible to minimize memory usage and improve performance.
+**File operations that don't lie** — magic-byte MIME detection catches spoofed extensions, size + content validation is built in, and presigned S3 uploads are one call away. Stream-first so a 2 GB upload doesn't blow your Lambda memory.
 
 ![NPM Version](https://img.shields.io/npm/v/%40smooai%2Ffile?style=for-the-badge)
 ![NPM Downloads](https://img.shields.io/npm/dw/%40smooai%2Ffile?style=for-the-badge)
@@ -74,55 +74,34 @@ Language-specific source code lives in the [`python/`](./python/), [`rust/`](./r
 
 The .NET port uses [Mime-Detective](https://github.com/MediatedCommunications/Mime-Detective) for magic-byte MIME sniffing and splits S3 helpers into a sub-package so consumers who don't need AWS avoid pulling in the AWS SDK.
 
-### Key Features
+### What you get
 
-#### 🚀 Stream-First Design
+#### 🔒 Trust the bytes, not the extension
 
-- Lazy loading of file contents
-- Memory-efficient processing
-- Automatic stream handling
-- Support for both Node.js and Web streams
+Magic-byte MIME detection catches spoofed uploads. A `.php` renamed to `avatar.png` fails validation because the bytes disagree with the claim.
 
-#### 📦 Multiple File Sources
+- Magic-byte detection across 100+ file types
+- `FileContentMismatchError` when client-claimed MIME disagrees with the bytes
+- `FileSizeError` / `FileMimeError` for oversize or disallowed uploads
+- One `validate()` call, typed error types, map cleanly to HTTP 400
 
-- **Local Filesystem**
-    - Read and write operations
-    - File system checks
-    - Metadata extraction
+#### ☁️ S3 in one call
 
-- **URLs**
-    - Automatic download
-    - Stream-based transfer
-    - Header metadata extraction
+- Stream any file (local, URL, Blob) straight into S3
+- Pull S3 objects back through the same validation pipeline
+- Presigned upload URLs with `maxSize` baked into the signature, so oversized uploads are rejected by S3 before they hit you
 
-- **S3 Objects**
-    - Direct S3 integration (download and upload)
-    - Stream-based transfer
-    - Header metadata extraction
-    - Signed URL generation
+#### 🌐 One API, many sources
 
-- **FormData**
-    - Ease of use for Multipart FormData upload
+Local filesystem, URL download, S3 object, multipart FormData, or a browser `File`/`Blob` — all resolve to the same `File` instance with the same validation and metadata surface.
 
-#### 🔍 Intelligent File Type Detection
+#### 🚀 Stream-first under the hood
 
-Powered by [file-type](https://github.com/sindresorhus/file-type), providing:
+Bytes load lazily so a 2 GB upload doesn't buffer into memory. Automatic handling across Node.js and Web streams — you never have to pick the right pipe.
 
-- Magic number detection
-- MIME type inference
-- File extension detection
-- Support for 100+ file types
+#### 📝 Rich metadata
 
-#### 📝 Rich Metadata
-
-- File name and extension
-- MIME type detection
-- File size
-- Last modified date
-- Creation date
-- File hash/checksum
-- URL and path information
-- Source type
+File name, real (detected) MIME type, size, created/modified timestamps, hash/checksum, source type — all on one object.
 
 ### Examples
 

--- a/go/file/README.md
+++ b/go/file/README.md
@@ -41,7 +41,7 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ## About smooai-file (Go)
 
-A powerful file handling package for Go that provides a unified interface for working with files from local filesystem, S3, URLs, bytes, and streams. Built with memory efficiency in mind — file bytes are eagerly buffered but the interface is designed for minimal allocations and straightforward, idiomatic Go error handling.
+**File operations that don't lie** — magic-byte MIME detection catches spoofed extensions, size + content validation is built in, and local / URL / S3 / bytes / stream sources all speak the same typed Go API. Interface-backed S3 and HTTP clients so tests mock cleanly.
 
 ![GitHub License](https://img.shields.io/github/license/SmooAI/file?style=for-the-badge)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/SmooAI/file/release.yml?style=for-the-badge)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@smooai/file",
     "version": "2.2.1",
-    "description": "A powerful file handling library for Node.js that provides a unified interface for working with files from local filesystem, S3, URLs, and more. Built with streaming in mind, it handles file bytes lazily where possible to minimize memory usage and improve performance.",
+    "description": "File operations that don't lie — magic-byte MIME detection catches spoofed extensions, size + content validation is built in, and presigned S3 uploads are one call away. Stream-first so large uploads don't blow your memory.",
     "homepage": "https://github.com/SmooAI/file#readme",
     "bugs": {
         "url": "https://github.com/SmooAI/file/issues"

--- a/python/README.md
+++ b/python/README.md
@@ -41,7 +41,7 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ## About smooai-file (Python)
 
-A powerful file handling library for Python that provides a unified async interface for working with files from local filesystem, S3, URLs, bytes, and streams. Built stream-first for memory efficiency — file bytes are handled lazily where possible to minimize memory pressure and improve performance.
+**File operations that don't lie** — magic-byte MIME detection catches spoofed extensions, size + content validation is built in, and local / URL / S3 / bytes / stream sources all speak the same typed async API. Stream-first so a large upload doesn't blow your memory.
 
 ![PyPI Version](https://img.shields.io/pypi/v/smooai-file?style=for-the-badge)
 ![PyPI Downloads](https://img.shields.io/pypi/dw/smooai-file?style=for-the-badge)

--- a/rust/file/README.md
+++ b/rust/file/README.md
@@ -41,7 +41,7 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 ## About smooai-file (Rust)
 
-A powerful file handling crate for Rust that provides a unified async interface for working with files from local filesystem, S3, URLs, bytes, and streams. Built stream-first for memory efficiency — leveraging Tokio's async runtime and the `bytes::Bytes` type for zero-copy data handling where possible.
+**File operations that don't lie** — magic-byte MIME detection catches spoofed extensions, size + content validation is built in, and local / URL / S3 / bytes / stream sources all speak the same typed async API. Stream-first and zero-copy where it counts, so large uploads don't buffer into memory.
 
 ![Crates.io Version](https://img.shields.io/crates/v/smooai-file?style=for-the-badge)
 ![Crates.io Downloads](https://img.shields.io/crates/d/smooai-file?style=for-the-badge)


### PR DESCRIPTION
## Summary

Rewrite the root + Python/Rust/Go READMEs so the first scroll sells **what the package lets you do** (magic-byte MIME detection catches spoofed extensions, size + content validation is built in, presigned S3 uploads are one call away) instead of the stock "powerful file handling library for X that provides a unified interface…" boilerplate they all shared.

### What changed

- **Root `README.md`** — new value-frame lead; reordered "Key Features" → "What you get" so **validation** (content-vs-claim, size, MIME) is the first block, not the last; dropped generic "Intelligent File Type Detection" in favor of "Trust the bytes, not the extension".
- **Root `package.json`** — description updated to match the new lead (shows up on npm).
- **`python/README.md`**, **`rust/file/README.md`**, **`go/file/README.md`** — identical value-frame lead replacement.
- **`.NET` READMEs** (`SmooAI.File`, `SmooAI.File.S3`) — already value-framed ("Magic-byte MIME detection, typed validation errors, and stream helpers for .NET — because `Content-Type` headers lie."). Unchanged in this PR; they republish automatically via the changeset.
- **`.changeset/smoodev-664-readme-value-frame.md`** — patch bump so npm + PyPI + crates.io + Go + NuGet (SmooAI.File + SmooAI.File.S3) republish with the new READMEs.

## Test plan

- [x] `pnpm lint` + `pnpm typecheck` + `pnpm test` + `pnpm build` via pre-commit hook
- [x] Verified `.NET` csproj files still have `<PackageReadmeFile>README.md</PackageReadmeFile>` + `<None Include="README.md" Pack="true" PackagePath="\" />`
- [ ] Merge triggers changesets release → new version on npm + PyPI + crates.io + Go + NuGet with the new READMEs

Jira: [SMOODEV-664](https://smooai.atlassian.net/browse/SMOODEV-664)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SMOODEV-664]: https://smooai.atlassian.net/browse/SMOODEV-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ