### PR TITLE
SMOODEV-666: Multi-target SmooAI.File + SmooAI.File.S3 to net8.0;net9.0;net10.0

### DIFF
--- a/.changeset/smoodev-666-multi-target.md
+++ b/.changeset/smoodev-666-multi-target.md
@@ -1,0 +1,5 @@
+---
+'@smooai/file': patch
+---
+
+SMOODEV-666: Multi-target the SmooAI.File and SmooAI.File.S3 NuGet packages to `net8.0;net9.0;net10.0` so consumers on every current .NET LTS + STS release get a native `lib/` folder match. Mime-Detective 25.8.1 and AWSSDK.S3 4.0.22 resolve cleanly on all three TFMs — no per-TFM conditionals needed. Also bumped the repo's `dotnet/global.json` rollForward from `latestFeature` to `latestMajor` so the SDK 10 runner can satisfy the 8.0.0 floor.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,7 +49,10 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '8.0.x'
+                  dotnet-version: |
+                      8.0.x
+                      9.0.x
+                      10.0.x
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,10 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '8.0.x'
+                  dotnet-version: |
+                      8.0.x
+                      9.0.x
+                      10.0.x
 
             - name: Install dependencies
               run: pnpm install

--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
         "version": "8.0.0",
-        "rollForward": "latestFeature"
+        "rollForward": "latestMajor"
     }
 }

--- a/dotnet/src/SmooAI.File.S3/SmooAI.File.S3.csproj
+++ b/dotnet/src/SmooAI.File.S3/SmooAI.File.S3.csproj
@@ -1,10 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Multi-target so NuGet consumers on every current .NET LTS + STS release
+         (8, 9, 10) get a native lib/ folder match. Clear the single-TFM
+         <TargetFramework> inherited from Directory.Build.props — when both
+         are set the singular wins, which would collapse us back to net8.0. -->
+    <TargetFramework></TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <PackageId>SmooAI.File.S3</PackageId>
     <RootNamespace>SmooAI.File.S3</RootNamespace>
     <AssemblyName>SmooAI.File.S3</AssemblyName>
-    <Version>2.2.0</Version>
+    <Version>2.2.3</Version>
     <Description>S3 helpers for SmooAI.File — createPresignedUploadUrl, createFromS3, uploadToS3, saveToS3.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/dotnet/src/SmooAI.File/SmooAI.File.csproj
+++ b/dotnet/src/SmooAI.File/SmooAI.File.csproj
@@ -1,10 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Multi-target so NuGet consumers on every current .NET LTS + STS release
+         (8, 9, 10) get a native lib/ folder match. Clear the single-TFM
+         <TargetFramework> inherited from Directory.Build.props — when both
+         are set the singular wins, which would collapse us back to net8.0. -->
+    <TargetFramework></TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <PackageId>SmooAI.File</PackageId>
     <RootNamespace>SmooAI.File</RootNamespace>
     <AssemblyName>SmooAI.File</AssemblyName>
-    <Version>2.2.0</Version>
+    <Version>2.2.3</Version>
     <Description>File utilities with magic-byte MIME detection (via Mime-Detective) and typed validation errors. Use SmooAI.File.S3 for S3 upload/download helpers.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Switch `SmooAI.File.csproj` and `SmooAI.File.S3.csproj` from inherited `<TargetFramework>net8.0</TargetFramework>` (set in `dotnet/Directory.Build.props`) to `<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>` so both NuGet packages ship `lib/net{8,9,10}.0/*.dll` and consumers on every current .NET LTS + STS release get a native match.
- Because the inherited `TargetFramework` (singular) wins over a later `TargetFrameworks` (plural) when both are set, the two csprojs explicitly clear the singular before setting the plural — otherwise the build silently collapses back to net8.0 only.
- `dotnet/global.json` rollForward bumped from `latestFeature` to `latestMajor` so a runner with SDK 10 can satisfy the 8.0.0 floor (the multi-target build needs the SDK 10 pack).
- `Mime-Detective 25.8.1` and `AWSSDK.S3 4.0.22` resolve cleanly on all three TFMs — no per-TFM conditional needed.
- Update both .NET CI workflows (pr-checks, release) to install 8.0.x + 9.0.x + 10.0.x SDKs so the multi-target build resolves on the runner.

## Test plan
- [x] `dotnet restore` — resolves on all three TFMs locally
- [x] `dotnet build -c Release` — succeeds for net8.0, net9.0, net10.0 (6 DLLs: File + File.S3 × 3 TFMs)
- [x] `dotnet test -c Release` — File.Tests 20/20 + File.S3.Tests 4/4 pass (net8.0)
- [x] `dotnet pack` — inspected both nupkgs; each contains `lib/net{8,9,10}.0/*.dll`
- [x] Pre-commit hook (lint, typecheck, test, build, format) passed
- [ ] PR CI (ubuntu) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)