### PR TITLE
SMOODEV-956: Fix Python README — puremagic, not python-magic

### DIFF
--- a/.changeset/smoodev-956-readme-puremagic.md
+++ b/.changeset/smoodev-956-readme-puremagic.md
@@ -1,0 +1,5 @@
+---
+'@smooai/file': patch
+---
+
+SMOODEV-956: Fix Python README — `python/README.md` listed `python-magic` as the magic-byte MIME detector, but the package actually ships `puremagic` (per `pyproject.toml` + `_detection.py`, and noted in the 2.0.0 changelog). Update the "Built With" entry so Python users don't pip-install the wrong library.

--- a/python/README.md
+++ b/python/README.md
@@ -268,7 +268,7 @@ asyncio.run(main())
 - [aiofiles](https://github.com/Tinche/aiofiles) — async filesystem I/O
 - [httpx](https://www.python-httpx.org/) — async HTTP client for URL downloads
 - [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) — AWS SDK for S3 integration
-- [python-magic](https://github.com/ahupp/python-magic) — magic-byte MIME detection
+- [puremagic](https://github.com/cdgriffith/puremagic) — pure-Python magic-byte MIME detection (no libmagic system dep)
 
 ## Related Packages
 


### PR DESCRIPTION
Docs fix. python/README.md listed python-magic but pyproject.toml + _detection.py ship puremagic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)