### PR TITLE
SMOODEV-953: .NET port — Content-Disposition parsing

### DIFF
--- a/.changeset/SMOODEV-953-dotnet-content-disposition.md
+++ b/.changeset/SMOODEV-953-dotnet-content-disposition.md
@@ -1,0 +1,5 @@
+---
+'@smooai/file': patch
+---
+
+SMOODEV-953: .NET — add Content-Disposition parser (RFC 6266 / RFC 5987) and wire it into the URL and S3 download flows so `SmooFile.Name` picks up server-suggested filenames (including UTF-8 encoded ones) instead of silently falling back to the URL basename or S3 key.

--- a/dotnet/src/SmooAI.File.S3/S3SmooFile.cs
+++ b/dotnet/src/SmooAI.File.S3/S3SmooFile.cs
@@ -39,6 +39,13 @@ public static class S3SmooFile
 
         using var response = await s3.GetObjectAsync(bucket, key, ct).ConfigureAwait(false);
 
+        // Prefer a filename hint from the object's Content-Disposition over the
+        // bare S3 key — clients that set Content-Disposition explicitly are
+        // signaling what the file should be called when downloaded.
+        var dispositionFilename = ContentDisposition.ExtractFilename(response.Headers.ContentDisposition);
+        if (!string.IsNullOrEmpty(dispositionFilename))
+            options.Name = dispositionFilename;
+
         options.MimeType ??= response.Headers.ContentType;
         options.Size ??= response.ContentLength > 0 ? response.ContentLength : (long?)null;
         options.Hash ??= response.ETag?.Trim('"');

--- a/dotnet/src/SmooAI.File/ContentDisposition.cs
+++ b/dotnet/src/SmooAI.File/ContentDisposition.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace SmooAI.File;
+
+/// <summary>
+/// Parsed Content-Disposition header data.
+/// </summary>
+public sealed class ContentDispositionData
+{
+    /// <summary>The disposition type (e.g. "attachment", "inline"). Lowercased.</summary>
+    public string DispositionType { get; init; } = "";
+
+    /// <summary>The resolved filename. RFC 5987 (<c>filename*</c>) takes precedence over plain <c>filename</c>.</summary>
+    public string? Filename { get; init; }
+}
+
+/// <summary>
+/// Content-Disposition header parsing.
+///
+/// Extracts the filename from HTTP Content-Disposition headers following
+/// RFC 6266 / RFC 5987 patterns. Uses <see cref="ContentDispositionHeaderValue"/>
+/// as the primary parser (which handles most spec-compliant cases) and falls
+/// back to a manual regex parser for edge cases (e.g. spaces, mixed casing,
+/// missing quotes) that the BCL parser rejects.
+/// </summary>
+public static class ContentDisposition
+{
+    private static readonly Regex FilenameRegex = new(
+        @"filename\s*=\s*(?:""(?<v>[^""]*)""|(?<v>[^;]+))",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex FilenameStarRegex = new(
+        @"filename\*\s*=\s*(?<enc>[^']*)'[^']*'(?<v>[^;]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Parse a Content-Disposition header value. Returns <c>null</c> when the
+    /// input is null, empty, or unparseable.
+    /// </summary>
+    public static ContentDispositionData? Parse(string? header)
+    {
+        if (string.IsNullOrWhiteSpace(header)) return null;
+
+        // Primary: BCL parser (handles RFC 6266 + RFC 5987 encoded-word filenames).
+        if (ContentDispositionHeaderValue.TryParse(header, out var parsed))
+        {
+            var filename = TryUnquote(parsed.FileNameStar) ?? TryUnquote(parsed.FileName);
+            if (!string.IsNullOrEmpty(filename) || !string.IsNullOrEmpty(parsed.DispositionType))
+            {
+                return new ContentDispositionData
+                {
+                    DispositionType = (parsed.DispositionType ?? "").Trim().ToLowerInvariant(),
+                    Filename = string.IsNullOrEmpty(filename) ? FallbackFilename(header) : filename,
+                };
+            }
+        }
+
+        // Fallback: manual regex parse for malformed headers the BCL rejects.
+        var trimmed = header.Trim();
+        var semi = trimmed.IndexOf(';');
+        var dispositionType = (semi < 0 ? trimmed : trimmed[..semi]).Trim().ToLowerInvariant();
+        var fallback = FallbackFilename(trimmed);
+        if (fallback is null && string.IsNullOrEmpty(dispositionType)) return null;
+        return new ContentDispositionData { DispositionType = dispositionType, Filename = fallback };
+    }
+
+    /// <summary>
+    /// Extract just the filename from a Content-Disposition header. Convenience
+    /// wrapper around <see cref="Parse(string)"/>.
+    /// </summary>
+    public static string? ExtractFilename(string? header) => Parse(header)?.Filename;
+
+    /// <summary>
+    /// Extract the filename from a parsed <see cref="ContentDispositionHeaderValue"/>.
+    /// RFC 6266 says <c>filename*</c> wins over <c>filename</c>.
+    /// </summary>
+    public static string? ExtractFilename(ContentDispositionHeaderValue? disposition)
+    {
+        if (disposition is null) return null;
+        return TryUnquote(disposition.FileNameStar) ?? TryUnquote(disposition.FileName);
+    }
+
+    private static string? FallbackFilename(string header)
+    {
+        // filename* takes precedence over filename per RFC 6266.
+        var star = FilenameStarRegex.Match(header);
+        if (star.Success)
+        {
+            var enc = star.Groups["enc"].Value.Trim();
+            var raw = star.Groups["v"].Value.Trim().Trim('"');
+            return DecodePercent(raw, enc);
+        }
+
+        var plain = FilenameRegex.Match(header);
+        if (plain.Success)
+        {
+            return plain.Groups["v"].Value.Trim().Trim('"');
+        }
+        return null;
+    }
+
+    private static string? TryUnquote(string? s)
+    {
+        if (string.IsNullOrEmpty(s)) return null;
+        var trimmed = s.Trim();
+        if (trimmed.Length >= 2 && trimmed.StartsWith('"') && trimmed.EndsWith('"'))
+            trimmed = trimmed[1..^1];
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+
+    private static string DecodePercent(string input, string encoding)
+    {
+        var enc = string.IsNullOrEmpty(encoding) ? Encoding.UTF8 : SafeEncoding(encoding);
+        var bytes = new System.Collections.Generic.List<byte>(input.Length);
+        var span = input.AsSpan();
+        for (int i = 0; i < span.Length; i++)
+        {
+            if (span[i] == '%' && i + 2 < span.Length &&
+                byte.TryParse(span.Slice(i + 1, 2), System.Globalization.NumberStyles.HexNumber,
+                    System.Globalization.CultureInfo.InvariantCulture, out var b))
+            {
+                bytes.Add(b);
+                i += 2;
+            }
+            else
+            {
+                // Plain ASCII char from the source — encode it via the target encoding.
+                foreach (var nb in enc.GetBytes(new[] { span[i] }))
+                    bytes.Add(nb);
+            }
+        }
+        return enc.GetString(bytes.ToArray());
+    }
+
+    private static Encoding SafeEncoding(string name)
+    {
+        try { return Encoding.GetEncoding(name); }
+        catch { return Encoding.UTF8; }
+    }
+}

--- a/dotnet/src/SmooAI.File/SmooFile.cs
+++ b/dotnet/src/SmooAI.File/SmooFile.cs
@@ -274,7 +274,9 @@ public sealed class SmooFile
         using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
-        options.Name ??= ParseFilename(response.Content.Headers.ContentDisposition) ?? FilenameFromUrl(url);
+        options.Name ??= ContentDisposition.ExtractFilename(response.Content.Headers.ContentDisposition)
+            ?? ContentDisposition.ExtractFilename(GetRawContentDisposition(response))
+            ?? FilenameFromUrl(url);
         options.MimeType ??= response.Content.Headers.ContentType?.MediaType;
         options.Size ??= response.Content.Headers.ContentLength;
         options.LastModified ??= response.Content.Headers.LastModified;
@@ -314,10 +316,14 @@ public sealed class SmooFile
         return string.IsNullOrEmpty(ext) ? null : ext.TrimStart('.').ToLowerInvariant();
     }
 
-    private static string? ParseFilename(ContentDispositionHeaderValue? disposition)
+    private static string? GetRawContentDisposition(HttpResponseMessage response)
     {
-        if (disposition is null) return null;
-        return disposition.FileNameStar?.Trim('"') ?? disposition.FileName?.Trim('"');
+        if (response.Content.Headers.TryGetValues("Content-Disposition", out var values))
+        {
+            foreach (var v in values)
+                if (!string.IsNullOrEmpty(v)) return v;
+        }
+        return null;
     }
 
     private static string? FilenameFromUrl(string url)

--- a/dotnet/tests/SmooAI.File.Tests/ContentDispositionTests.cs
+++ b/dotnet/tests/SmooAI.File.Tests/ContentDispositionTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SmooAI.File.Tests;
+
+public class ContentDispositionTests
+{
+    [Fact]
+    public void Parse_PlainQuotedFilename_Extracts()
+    {
+        var cd = ContentDisposition.Parse("attachment; filename=\"example.pdf\"");
+        Assert.NotNull(cd);
+        Assert.Equal("attachment", cd!.DispositionType);
+        Assert.Equal("example.pdf", cd.Filename);
+    }
+
+    [Fact]
+    public void Parse_UnquotedFilename_Extracts()
+    {
+        var cd = ContentDisposition.Parse("attachment; filename=example.pdf");
+        Assert.Equal("example.pdf", cd!.Filename);
+    }
+
+    [Fact]
+    public void Parse_Rfc5987EncodedFilename_Decodes()
+    {
+        // %E4%BD%A0 → "你" (UTF-8)
+        var cd = ContentDisposition.Parse("attachment; filename*=UTF-8''%E4%BD%A0.pdf");
+        Assert.NotNull(cd);
+        Assert.Equal("你.pdf", cd!.Filename);
+    }
+
+    [Fact]
+    public void Parse_FilenameStarTakesPrecedence_OverPlainFilename()
+    {
+        var cd = ContentDisposition.Parse("attachment; filename=\"fallback.txt\"; filename*=UTF-8''preferred.txt");
+        Assert.Equal("preferred.txt", cd!.Filename);
+    }
+
+    [Fact]
+    public void Parse_InlineDisposition_Extracts()
+    {
+        var cd = ContentDisposition.Parse("inline; filename=\"photo.jpg\"");
+        Assert.Equal("inline", cd!.DispositionType);
+        Assert.Equal("photo.jpg", cd.Filename);
+    }
+
+    [Fact]
+    public void Parse_EmptyOrNull_ReturnsNull()
+    {
+        Assert.Null(ContentDisposition.Parse(null));
+        Assert.Null(ContentDisposition.Parse(""));
+        Assert.Null(ContentDisposition.Parse("   "));
+    }
+
+    [Fact]
+    public void ExtractFilename_FromHeaderValue_HandlesNullDisposition()
+    {
+        Assert.Null(ContentDisposition.ExtractFilename((ContentDispositionHeaderValue?)null));
+    }
+
+    [Fact]
+    public void ExtractFilename_FromHeaderValue_PrefersFilenameStar()
+    {
+        var hdr = new ContentDispositionHeaderValue("attachment")
+        {
+            FileName = "\"plain.txt\"",
+            FileNameStar = "preferred.txt",
+        };
+        Assert.Equal("preferred.txt", ContentDisposition.ExtractFilename(hdr));
+    }
+
+    [Fact]
+    public async Task CreateFromUrlAsync_FallsBackToUrlBasename_WhenHeaderMissing()
+    {
+        var handler = new StubHandler(setDisposition: false);
+        using var client = new HttpClient(handler);
+        var file = await SmooFile.CreateFromUrlAsync("https://example.com/path/report.pdf", client);
+        Assert.Equal("report.pdf", file.Name);
+    }
+
+    [Fact]
+    public async Task CreateFromUrlAsync_UsesContentDispositionFilename_WhenPresent()
+    {
+        var handler = new StubHandler(setDisposition: true, disposition: "attachment; filename=\"server-named.bin\"");
+        using var client = new HttpClient(handler);
+        var file = await SmooFile.CreateFromUrlAsync("https://example.com/path/ignored.pdf", client);
+        Assert.Equal("server-named.bin", file.Name);
+    }
+
+    [Fact]
+    public async Task CreateFromUrlAsync_UsesRfc5987EncodedFilename_WhenPresent()
+    {
+        var handler = new StubHandler(setDisposition: true, disposition: "attachment; filename*=UTF-8''%E4%BD%A0.pdf");
+        using var client = new HttpClient(handler);
+        var file = await SmooFile.CreateFromUrlAsync("https://example.com/path/ignored.pdf", client);
+        Assert.Equal("你.pdf", file.Name);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly bool _setDisposition;
+        private readonly string? _disposition;
+
+        public StubHandler(bool setDisposition, string? disposition = null)
+        {
+            _setDisposition = setDisposition;
+            _disposition = disposition;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        {
+            var content = new ByteArrayContent(TestBytes.Png);
+            content.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+            if (_setDisposition && _disposition is not null)
+                content.Headers.TryAddWithoutValidation("Content-Disposition", _disposition);
+            var resp = new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+            return Task.FromResult(resp);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ContentDisposition` parser to `SmooAI.File` (RFC 6266 / RFC 5987) using BCL `ContentDispositionHeaderValue` primarily and a regex fallback for malformed headers
- Wire into `SmooFile.CreateFromUrlAsync` (HTTP response Content-Disposition)
- Wire into `S3SmooFile.CreateFromS3Async` (S3 object Content-Disposition metadata)
- xunit coverage: plain filename, RFC 5987 UTF-8 encoded filename, missing header fallback to URL basename, filename* precedence

Closes parity gap with TS / Python / Rust / Go.

## Test plan

- [x] `dotnet test tests/SmooAI.File.Tests/` — 31 passed
- [x] `dotnet test tests/SmooAI.File.S3.Tests/` — 4 passed