### PR TITLE
SMOODEV-954: Go — ContentDisposition in presigned upload

### DIFF
--- a/.changeset/SMOODEV-954-go-presigned-upload.md
+++ b/.changeset/SMOODEV-954-go-presigned-upload.md
@@ -1,0 +1,5 @@
+---
+'@smooai/file': patch
+---
+
+SMOODEV-954: Go — extend `CreatePresignedUploadURL` with `ContentDisposition` option so callers can pre-set the suggested filename for downloads (`attachment; filename="..."`) baked into the signed PUT URL. Brings Go to parity with TS/Rust/Python/.NET.

--- a/go/file/file.go
+++ b/go/file/file.go
@@ -503,6 +503,12 @@ type PresignedUploadOptions struct {
 	// client cannot PUT a larger object. Not all HTTP clients actually send
 	// Content-Length, so servers should still validate on a subsequent HEAD.
 	MaxSize int64
+
+	// ContentDisposition, if non-empty, is baked into the signature so the
+	// stored object will be served with this Content-Disposition header. Use
+	// this to pre-set the suggested filename for downloads, e.g.
+	// `attachment; filename="user-photo.png"`.
+	ContentDisposition string
 }
 
 // CreatePresignedUploadURL generates a presigned S3 PUT URL so a client can
@@ -528,9 +534,10 @@ func CreatePresignedUploadURL(ctx context.Context, bucket, key string, opts *Pre
 	_, presignClient := S3ClientFactory()
 
 	input := &s3.PutObjectInput{
-		Bucket:      aws.String(bucket),
-		Key:         aws.String(key),
-		ContentType: nilIfEmpty(o.ContentType),
+		Bucket:             aws.String(bucket),
+		Key:                aws.String(key),
+		ContentType:        nilIfEmpty(o.ContentType),
+		ContentDisposition: nilIfEmpty(o.ContentDisposition),
 	}
 	if o.MaxSize > 0 {
 		input.ContentLength = aws.Int64(o.MaxSize)

--- a/go/file/helpers_test.go
+++ b/go/file/helpers_test.go
@@ -407,6 +407,50 @@ func TestCreatePresignedUploadURL_ValidatesArgs(t *testing.T) {
 	}
 }
 
+func TestCreatePresignedUploadURL_ContentDisposition(t *testing.T) {
+	var capturedCD *string
+
+	presign := &mockPresignClient{
+		presignPutObjectFn: func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.PresignOptions)) (*v4.PresignedHTTPRequest, error) {
+			capturedCD = params.ContentDisposition
+			return &v4.PresignedHTTPRequest{URL: "https://signed.example/", Method: "PUT"}, nil
+		},
+	}
+	cleanup := setMockS3(&mockS3Client{}, presign)
+	defer cleanup()
+
+	_, err := CreatePresignedUploadURL(context.Background(), "bucket", "uploads/file.bin", &PresignedUploadOptions{
+		ContentDisposition: `attachment; filename="user-photo.png"`,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedCD == nil || *capturedCD != `attachment; filename="user-photo.png"` {
+		t.Errorf("ContentDisposition = %v, want attachment; filename=\"user-photo.png\"", capturedCD)
+	}
+}
+
+func TestCreatePresignedUploadURL_EmptyContentDisposition_NotSet(t *testing.T) {
+	var capturedCD *string
+
+	presign := &mockPresignClient{
+		presignPutObjectFn: func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.PresignOptions)) (*v4.PresignedHTTPRequest, error) {
+			capturedCD = params.ContentDisposition
+			return &v4.PresignedHTTPRequest{URL: "https://signed.example/", Method: "PUT"}, nil
+		},
+	}
+	cleanup := setMockS3(&mockS3Client{}, presign)
+	defer cleanup()
+
+	_, err := CreatePresignedUploadURL(context.Background(), "bucket", "key", &PresignedUploadOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedCD != nil {
+		t.Errorf("ContentDisposition should be nil when empty, got %q", *capturedCD)
+	}
+}
+
 func TestCreatePresignedUploadURL_SigningError(t *testing.T) {
 	presign := &mockPresignClient{
 		presignPutObjectFn: func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.PresignOptions)) (*v4.PresignedHTTPRequest, error) {


### PR DESCRIPTION
## Summary

- Adds `ContentDisposition string` field to `PresignedUploadOptions`
- Baked into the signed `PutObject` so the stored object will be served with the configured Content-Disposition header
- Brings Go to parity with TS/Rust/Python/.NET (MaxSize, bucket/key validation, ExpiresIn were already implemented)

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 147 passed