### PR TITLE
SMOODEV-951: createFromWebFile parity (Python/Rust/Go/.NET)

### DIFF
--- a/.changeset/SMOODEV-951-create-from-webfile.md
+++ b/.changeset/SMOODEV-951-create-from-webfile.md
@@ -1,0 +1,10 @@
+---
+'@smooai/file': patch
+---
+
+SMOODEV-951: Bring Python, Rust, Go, and .NET to parity with TS's `createFromWebFile` (overdue v2.1.0 follow-up). Each port adds an idiomatic factory for ingesting a form/multipart upload from a web framework:
+
+- Python: `File.from_form_upload(upload)` — accepts any object exposing `filename` + `content_type` + `read()` (Starlette `UploadFile`, FastAPI `UploadFile`, aiohttp `FileField`)
+- Rust: `File::from_form_upload(bytes, filename, content_type)` — framework-agnostic; callers pull these fields from axum/actix Multipart fields
+- Go: `NewFromMultipartFile(*multipart.FileHeader)` — stdlib `net/http` multipart type
+- .NET: `SmooFile.CreateFromFormFileAsync(Stream, fileName, contentType)` — callers pass `IFormFile.OpenReadStream(), FileName, ContentType` to avoid forcing the ASP.NET dep on every consumer

--- a/dotnet/src/SmooAI.File/SmooFile.cs
+++ b/dotnet/src/SmooAI.File/SmooFile.cs
@@ -284,6 +284,37 @@ public sealed class SmooFile
     }
 
     /// <summary>
+    /// Create a <see cref="SmooFile"/> from an ASP.NET Core <c>IFormFile</c>-style
+    /// upload. Rather than referencing <c>Microsoft.AspNetCore.Http</c> directly
+    /// (which would force the dep on every consumer), this overload takes the
+    /// three fields <c>IFormFile</c> exposes — call site looks like:
+    /// <code>
+    /// await SmooFile.CreateFromFormFileAsync(formFile.OpenReadStream(), formFile.FileName, formFile.ContentType);
+    /// </code>
+    /// Mirrors TS's <c>createFromWebFile</c>.
+    /// </summary>
+    public static async Task<SmooFile> CreateFromFormFileAsync(
+        Stream stream,
+        string? fileName = null,
+        string? contentType = null,
+        Action<SmooFileOptions>? configure = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        var options = new SmooFileOptions
+        {
+            Name = string.IsNullOrEmpty(fileName) ? null : fileName,
+            MimeType = string.IsNullOrEmpty(contentType) ? null : contentType,
+        };
+        configure?.Invoke(options);
+
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms, ct).ConfigureAwait(false);
+        var bytes = ms.ToArray();
+        return BuildFromBytes(FileSource.Stream, bytes, options);
+    }
+
+    /// <summary>
     /// Download a URL and create a <see cref="SmooFile"/> from the response body.
     /// Optionally pass an <see cref="HttpClient"/>; otherwise a shared one is used.
     /// </summary>

--- a/dotnet/tests/SmooAI.File.Tests/CreateFromFormFileTests.cs
+++ b/dotnet/tests/SmooAI.File.Tests/CreateFromFormFileTests.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SmooAI.File.Tests;
+
+public class CreateFromFormFileTests
+{
+    [Fact]
+    public async Task PreservesFilenameAndContentTypeFromHints()
+    {
+        using var ms = new MemoryStream(TestBytes.Png);
+        var file = await SmooFile.CreateFromFormFileAsync(ms, "pic.png", "image/png");
+        Assert.Equal("pic.png", file.Name);
+        // Magic-byte detection wins (still image/png because bytes are PNG).
+        Assert.Equal("image/png", file.MimeType);
+        Assert.Equal(TestBytes.Png, await file.ReadBytesAsync());
+    }
+
+    [Fact]
+    public async Task MissingNameAndContentType_StillBuildsFile()
+    {
+        using var ms = new MemoryStream(TestBytes.Png);
+        var file = await SmooFile.CreateFromFormFileAsync(ms);
+        // Magic-byte detection still kicks in.
+        Assert.Equal("image/png", file.MimeType);
+    }
+
+    [Fact]
+    public async Task ConfigureOptionsOverride_FromHints()
+    {
+        using var ms = new MemoryStream(TestBytes.Png);
+        var file = await SmooFile.CreateFromFormFileAsync(ms, "original.png", "image/png", o => o.Name = "renamed.png");
+        Assert.Equal("renamed.png", file.Name);
+    }
+}

--- a/go/file/file.go
+++ b/go/file/file.go
@@ -160,6 +160,60 @@ func NewFromFile(filePath string, hints ...MetadataHint) (*File, error) {
 	}, nil
 }
 
+// NewFromMultipartFile creates a File from a stdlib `*multipart.FileHeader`,
+// the type carried in `http.Request.MultipartForm.File`. The TS port exposes
+// `createFromWebFile` for the same scenario; this is the Go-native equivalent
+// for multipart upload routes.
+//
+// Filename and Content-Type from the part headers are preserved as metadata
+// hints unless overridden by `hints`.
+func NewFromMultipartFile(fh *multipart.FileHeader, hints ...MetadataHint) (*File, error) {
+	if fh == nil {
+		return nil, newError(ErrInvalidSource, "NewFromMultipartFile", fmt.Errorf("file header is nil"))
+	}
+
+	src, err := fh.Open()
+	if err != nil {
+		return nil, newError(ErrRead, "NewFromMultipartFile", err)
+	}
+	defer src.Close()
+
+	data, err := io.ReadAll(src)
+	if err != nil {
+		return nil, newError(ErrRead, "NewFromMultipartFile", err)
+	}
+
+	// Build hint: start from the multipart headers, layer caller overrides on top.
+	hint := MetadataHint{
+		Name:     fh.Filename,
+		MimeType: fh.Header.Get("Content-Type"),
+	}
+	if len(hints) > 0 {
+		override := hints[0]
+		if override.Name != "" {
+			hint.Name = override.Name
+		}
+		if override.MimeType != "" {
+			hint.MimeType = override.MimeType
+		}
+		if override.Size != 0 {
+			hint.Size = override.Size
+		}
+		if override.Extension != "" {
+			hint.Extension = override.Extension
+		}
+	}
+
+	meta := resolveMetadataFromBytes(data, hint)
+
+	return &File{
+		source: SourceStream,
+		meta:   meta,
+		data:   data,
+		loaded: true,
+	}, nil
+}
+
 // NewFromStream creates a File from an io.Reader. The stream content is read
 // eagerly into memory.
 func NewFromStream(r io.Reader, hints ...MetadataHint) (*File, error) {

--- a/go/file/helpers_test.go
+++ b/go/file/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net/textproto"
 	"strings"
 	"testing"
 	"time"
@@ -289,6 +290,82 @@ func TestFileValidationError_ErrorMessages(t *testing.T) {
 				t.Errorf("Error() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// --- NewFromMultipartFile ---
+
+func TestNewFromMultipartFile_ExtractsFilenameAndContentType(t *testing.T) {
+	// Build a real multipart body and parse it back to get a *FileHeader,
+	// then feed it to NewFromMultipartFile.
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", `form-data; name="upload"; filename="pic.png"`)
+	header.Set("Content-Type", "image/png")
+	part, err := writer.CreatePart(header)
+	if err != nil {
+		t.Fatalf("CreatePart: %v", err)
+	}
+	if _, err := part.Write(pngBytes); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	writer.Close()
+
+	reader := multipart.NewReader(body, writer.Boundary())
+	form, err := reader.ReadForm(1 << 20)
+	if err != nil {
+		t.Fatalf("ReadForm: %v", err)
+	}
+	defer form.RemoveAll()
+
+	fh := form.File["upload"][0]
+	f, err := NewFromMultipartFile(fh)
+	if err != nil {
+		t.Fatalf("NewFromMultipartFile: %v", err)
+	}
+	if f.Name() != "pic.png" {
+		t.Errorf("Name = %q, want pic.png", f.Name())
+	}
+	if f.MimeType() == "" {
+		t.Error("MimeType should not be empty")
+	}
+	read, _ := f.Read()
+	if !bytes.Equal(read, pngBytes) {
+		t.Error("file bytes do not round-trip")
+	}
+}
+
+func TestNewFromMultipartFile_NilFails(t *testing.T) {
+	_, err := NewFromMultipartFile(nil)
+	if err == nil {
+		t.Fatal("expected error for nil FileHeader")
+	}
+	if !errors.Is(err, ErrInvalidSource) {
+		t.Errorf("expected ErrInvalidSource, got %v", err)
+	}
+}
+
+func TestNewFromMultipartFile_HintsOverrideMultipartMetadata(t *testing.T) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", `form-data; name="upload"; filename="original.bin"`)
+	header.Set("Content-Type", "application/octet-stream")
+	part, _ := writer.CreatePart(header)
+	part.Write([]byte("payload"))
+	writer.Close()
+
+	reader := multipart.NewReader(body, writer.Boundary())
+	form, _ := reader.ReadForm(1 << 20)
+	defer form.RemoveAll()
+
+	f, err := NewFromMultipartFile(form.File["upload"][0], MetadataHint{Name: "renamed.bin"})
+	if err != nil {
+		t.Fatalf("NewFromMultipartFile: %v", err)
+	}
+	if f.Name() != "renamed.bin" {
+		t.Errorf("Name = %q, want renamed.bin", f.Name())
 	}
 }
 

--- a/python/src/smooai_file/_file.py
+++ b/python/src/smooai_file/_file.py
@@ -295,6 +295,76 @@ class File:
         return cls(FileSource.STREAM, metadata, data=data)
 
     # ------------------------------------------------------------------
+    # Factory: from_form_upload
+    # ------------------------------------------------------------------
+    @classmethod
+    async def from_form_upload(
+        cls,
+        upload: object,
+        metadata_hint: MetadataHint | None = None,
+    ) -> File:
+        """Create a File from an ASGI / web framework form-upload object.
+
+        Mirrors the TS port's ``File.createFromWebFile`` for relay/proxy and
+        multipart-route scenarios. Accepts any object that quacks like
+        Starlette's ``UploadFile`` or aiohttp's ``FileField``:
+
+        - ``filename`` (str | None)
+        - ``content_type`` (str | None)
+        - ``file`` (sync file-like, has ``read``) **or** ``read()`` directly
+          (async or sync), returned bytes.
+
+        Caller-supplied ``metadata_hint`` overrides hints from the upload.
+
+        Args:
+            upload: A web framework form-upload object (Starlette ``UploadFile``,
+                aiohttp ``FileField``, FastAPI ``UploadFile``, etc.).
+            metadata_hint: Optional metadata hints that override the upload's
+                own hints.
+
+        Returns:
+            A new ``File`` instance.
+
+        Examples:
+            In a FastAPI route::
+
+                @app.post("/upload")
+                async def upload(file: UploadFile):
+                    smoo = await File.from_form_upload(file)
+                    await smoo.validate(max_size=5_000_000)
+        """
+        # Drain the upload into bytes. Try async read() first (Starlette,
+        # FastAPI), then sync .file.read() (aiohttp FileField), then sync
+        # read() as a last resort.
+        data: bytes
+        read = getattr(upload, "read", None)
+        if callable(read):
+            result = read()
+            if hasattr(result, "__await__"):
+                data = await result  # type: ignore[assignment, misc]
+            else:
+                data = result  # type: ignore[assignment]
+        else:
+            file_attr = getattr(upload, "file", None)
+            if file_attr is not None and hasattr(file_attr, "read"):
+                data = file_attr.read()
+            else:
+                raise TypeError("upload must expose a read() method (async or sync) or a .file attribute with read()")
+
+        filename = getattr(upload, "filename", None) or None
+        content_type = getattr(upload, "content_type", None) or None
+
+        hint: MetadataHint = {}
+        if filename:
+            hint["name"] = filename
+        if content_type:
+            hint["mime_type"] = content_type
+        if metadata_hint:
+            hint.update(metadata_hint)
+
+        return await cls.from_bytes(data, metadata_hint=hint)
+
+    # ------------------------------------------------------------------
     # Factory: from_s3
     # ------------------------------------------------------------------
     @classmethod

--- a/python/tests/test_helpers.py
+++ b/python/tests/test_helpers.py
@@ -160,6 +160,60 @@ class TestToBase64:
 
 
 # ---------------------------------------------------------------------------
+# File.from_form_upload
+# ---------------------------------------------------------------------------
+
+
+class TestFromFormUpload:
+    async def test_starlette_style_async_read(self) -> None:
+        # Stub UploadFile: async read(), filename, content_type attrs.
+        class _Upload:
+            filename = "report.pdf"
+            content_type = "application/pdf"
+
+            async def read(self) -> bytes:
+                return b"%PDF-1.4 stub"
+
+        f = await File.from_form_upload(_Upload())
+        assert f.name == "report.pdf"
+        # Content-type hint preserved as a fallback when magic-byte detection
+        # doesn't run on this short stub.
+        assert f.mime_type in ("application/pdf", None) or f.mime_type.startswith("application/")
+        assert await f.read() == b"%PDF-1.4 stub"
+
+    async def test_aiohttp_style_sync_file_attr(self) -> None:
+        # Stub FileField: sync .file attr + filename + content_type.
+        import io
+
+        class _FileField:
+            filename = "photo.jpg"
+            content_type = "image/jpeg"
+            file = io.BytesIO(b"\xff\xd8\xff\xe0bytes")
+
+        f = await File.from_form_upload(_FileField())
+        assert f.name == "photo.jpg"
+        assert await f.read() == b"\xff\xd8\xff\xe0bytes"
+
+    async def test_metadata_hint_overrides_upload(self) -> None:
+        class _Upload:
+            filename = "original.bin"
+            content_type = "application/octet-stream"
+
+            async def read(self) -> bytes:
+                return b"data"
+
+        f = await File.from_form_upload(_Upload(), metadata_hint={"name": "renamed.bin"})
+        assert f.name == "renamed.bin"
+
+    async def test_rejects_uploads_without_read(self) -> None:
+        class _Bad:
+            filename = "no-read.txt"
+
+        with pytest.raises(TypeError):
+            await File.from_form_upload(_Bad())
+
+
+# ---------------------------------------------------------------------------
 # File.to_form_data
 # ---------------------------------------------------------------------------
 

--- a/rust/file/src/file.rs
+++ b/rust/file/src/file.rs
@@ -959,6 +959,36 @@ impl File {
         Ok(BASE64_STANDARD.encode(&self.data))
     }
 
+    /// Create a `File` from a web framework's form-upload field (axum's
+    /// `Multipart::Field`, actix's `Field`, etc). Rather than binding to one
+    /// framework, callers pass the three fields every framework exposes —
+    /// bytes, filename, content-type — and we wire them through the standard
+    /// `from_bytes` factory so detection and validation still run. Mirrors TS's
+    /// `createFromWebFile`.
+    ///
+    /// # Example
+    /// ```ignore
+    /// // axum
+    /// while let Some(field) = multipart.next_field().await? {
+    ///     let name = field.file_name().map(|s| s.to_string());
+    ///     let ct = field.content_type().map(|s| s.to_string());
+    ///     let bytes = field.bytes().await?;
+    ///     let file = File::from_form_upload(bytes, name, ct).await?;
+    /// }
+    /// ```
+    pub async fn from_form_upload(
+        bytes: Bytes,
+        filename: Option<String>,
+        content_type: Option<String>,
+    ) -> Result<Self> {
+        let hint = MetadataHint {
+            name: filename,
+            mime_type: content_type,
+            ..Default::default()
+        };
+        File::from_bytes(bytes, Some(hint)).await
+    }
+
     /// Convert the file into a `reqwest::multipart::Form` ready to be sent
     /// with `RequestBuilder::multipart`. The TS port exposes the same helper
     /// for relay/proxy scenarios. The form contains a single field named
@@ -1352,6 +1382,29 @@ mod tests {
     async fn test_to_base64_empty() {
         let file = File::from_bytes(Bytes::new(), None).await.unwrap();
         assert_eq!(file.to_base64().await.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_from_form_upload_preserves_hints() {
+        let file = File::from_form_upload(
+            Bytes::from_static(b"hello"),
+            Some("greet.txt".into()),
+            Some("text/plain".into()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(file.name(), Some("greet.txt"));
+        // Magic-byte detection may override mime — but the size and name hints
+        // must persist.
+        assert_eq!(file.size(), Some(5));
+    }
+
+    #[tokio::test]
+    async fn test_from_form_upload_no_hints() {
+        let file = File::from_form_upload(Bytes::from_static(b"xx"), None, None)
+            .await
+            .unwrap();
+        assert!(file.name().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Overdue v2.1.0 follow-up. Adds an idiomatic form-upload factory to each port for multipart upload routes:

- **Python**: `File.from_form_upload(upload)` — duck-typed on `filename` + `content_type` + `read()` (Starlette/FastAPI `UploadFile`, aiohttp `FileField`)
- **Rust**: `File::from_form_upload(bytes, filename, content_type)` — framework-agnostic; avoids hard axum/actix dep
- **Go**: `NewFromMultipartFile(*multipart.FileHeader)` — stdlib `net/http`
- **.NET**: `SmooFile.CreateFromFormFileAsync(stream, fileName, contentType)` — accepts `IFormFile.OpenReadStream() + FileName + ContentType` without forcing ASP.NET dep

## Test plan

- [x] Python: `uv run pytest` — 130 passed
- [x] Rust: `cargo test` — 121 passed
- [x] Go: `go test ./...` — 152 passed
- [x] .NET: `dotnet test` — 37 passed