### PR TITLE
SMOODEV-955: Fix ruff I001 import order in test_helpers

### DIFF
--- a/python/tests/test_helpers.py
+++ b/python/tests/test_helpers.py
@@ -237,8 +237,8 @@ class TestToFormData:
     async def test_round_trip_via_email_parser(self, png_bytes: bytes) -> None:
         # Stub multipart parse — build a body from the form payload and parse it back.
         import email
-        from email.mime.multipart import MIMEMultipart
         from email.mime.application import MIMEApplication
+        from email.mime.multipart import MIMEMultipart
 
         f = await File.from_bytes(png_bytes, metadata_hint={"name": "pic.png"})
         form = await f.to_form_data("upload")


### PR DESCRIPTION
Trivial unblock. PR #49 introduced 3 inline imports in alphabetical-wrong order; ruff I001 blocked the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)