### PR TITLE
Drop create-entry-points — freeze manual entries

### DIFF
--- a/.changeset/drop-create-entry-points.md
+++ b/.changeset/drop-create-entry-points.md
@@ -1,0 +1,5 @@
+---
+'@smooai/file': patch
+---
+
+Drop create-entry-points dependency from build — freeze entry list in tsdown.config.ts + package.json exports. No public API change.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     },
     "scripts": {
         "aibranch": "pnpm generate-git-branch",
-        "build": "pnpm create-entry-points -i \"src/**/*.ts\" && pnpm tsdown && pnpm run python:build && pnpm run rust:build && pnpm run go:build",
+        "build": "pnpm tsdown && pnpm run python:build && pnpm run rust:build && pnpm run go:build",
         "check-all": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test && pnpm run python:typecheck && pnpm run python:lint && pnpm run python:format:check && pnpm run rust:fmt:check && pnpm run rust:lint && pnpm run rust:test && pnpm run go:fmt:check && pnpm run go:lint && pnpm run go:test && pnpm run build",
         "ci:publish": "pnpm build && pnpm changeset publish && pnpm run version:sync",
         "format": "oxfmt --write . && pnpm run python:format && pnpm run rust:fmt && pnpm run go:fmt",
@@ -90,7 +90,6 @@
         "@file-type/xml": "^0.4.1",
         "@smooai/fetch": "^3.3.5",
         "@smooai/logger": "^4.1.4",
-        "@smooai/utils": "^1.3.4",
         "content-disposition": "^0.5.4",
         "file-type": "^20.4.1",
         "formdata-node": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
       '@smooai/logger':
         specifier: ^4.1.4
         version: 4.1.4
-      '@smooai/utils':
-        specifier: ^1.3.4
-        version: 1.3.4(@types/node@22.13.10)(typescript@5.9.2)
       content-disposition:
         specifier: ^0.5.4
         version: 0.5.4


### PR DESCRIPTION
## Summary
- Hand-curated entry list in `tsdown.config.ts` + `package.json` exports (they were already identical to what `create-entry-points` would generate)
- Removed `pnpm create-entry-points -i "src/**/*.ts" && ` prefix from `scripts.build`
- Removed unused `@smooai/utils` dependency (no source imports of it — only the CLI used it)
- Patch bump via changeset

## Why
`create-entry-points` is being retired from `@smooai/utils` — only this repo and utils itself used it. Manual entry curation is trivial when adding a new file, and the build is simpler/clearer.

## Test plan
- [x] `pnpm install` clean
- [x] `pnpm tsdown` produces identical dist output (`index`, `errors`, `File` × cjs/mjs/d.cts/d.mts)
- [x] `pnpm exec vitest run` — 85 pass / 0 fail
- [x] `tsc --noEmit --skipLibCheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)